### PR TITLE
Fixed test suite in frontend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1507,6 +1507,7 @@
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.4.0.tgz",
       "integrity": "sha512-Y8DcyKK+4pl4B93ooiy1G8qvdyRMkcNFfBSh+8rbVcw4cW8dgG0VXCCTp5NUwub8sn9vSPsOwpb9tE2OuFmcfQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "^2.0.0",

--- a/frontend/src/__tests__/GroupTab.test.js
+++ b/frontend/src/__tests__/GroupTab.test.js
@@ -1,0 +1,12 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Grouptab from '../components/GroupTab.jsx';
+
+describe('Grouptab', () => {
+  it('renders group name and members', () => {
+    render(<Grouptab />);
+    expect(screen.getByText('Group 1')).toBeInTheDocument();
+    expect(screen.getByText('6 members')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('View Members'));
+    expect(screen.getAllByText('@katesmith0001').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/__tests__/Post.test.js
+++ b/frontend/src/__tests__/Post.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import Post from '../components/Post/Post';
+import Post from '../components/Post.jsx';
 
 describe('Post', () => {
   it('renders UserCard, PostData, and PollBox', () => {

--- a/frontend/src/__tests__/PostData.test.js
+++ b/frontend/src/__tests__/PostData.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import PostData from '../components/PostData/PostData';
+import PostData from '../components/PostData.jsx';
 
 describe('PostData', () => {
   it('renders question and images', () => {

--- a/frontend/src/__tests__/UserCard.test.js
+++ b/frontend/src/__tests__/UserCard.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import UserCard from '../components/UserCard/UserCard';
+import UserCard from '../components/UserCard.jsx';
 
 describe('UserCard', () => {
   const user = { name: 'testuser', profilePic: '/test.jpg' };

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import UserCard from "./UserCard";
 import PostData from "./PostData";
 import PollBox from "./PollBox";
@@ -13,5 +14,22 @@ const Post = ({user, group, post, pollOptions}) => {
     </div>
   )
 }
+
+
+Post.propTypes = {
+  user: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    profilePic: PropTypes.string,
+  }).isRequired,
+  group: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+  post: PropTypes.shape({
+    question: PropTypes.string,
+    content: PropTypes.array,
+    timeLeft: PropTypes.string,
+  }).isRequired,
+  pollOptions: PropTypes.array.isRequired,
+};
 
 export default Post;


### PR DESCRIPTION
#38 Updated the test cases for main components to use the correct .jsx file imports and mock data for props. The tests now reliably check component rendering without relying on backend data. 

To run, cd frontend then input: npm test -- --watchAll