### PR TITLE
Removed View group from Home screen

### DIFF
--- a/frontend/src/components/ScreenTab.jsx
+++ b/frontend/src/components/ScreenTab.jsx
@@ -42,18 +42,8 @@ export default function ScreenTab() {
               />
               <p className="font-semibold text-base text-black">Create Post</p>
         </Link>
-                <Link
-            to="/create"
-            className="flex items-center p-2 rounded-xl bg-backgroundGrey gap-3 hover:bg-lightYellow"
-          >
-              <img
-                src="/groups.svg"
-                alt="groups icon"
-                style={{ width: "1.5em", height: "1.5em" }}
-              />
-              <p className="font-semibold text-base text-black">View Group</p>
-        </Link>
       </div>
     </div>
+
   );
 }


### PR DESCRIPTION
### Altered the Screen Tab on the Home Page #40 

**Changes Made**

- Removed the 'View Group' clickable field because logically there is no group page that exists without a specific group id